### PR TITLE
shadcnのbadgeコンポーネントを追加

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,9 @@ const compat = new FlatCompat({
 })
 
 const eslintConfig = [
+  {
+    ignores: ['.next/'],
+  },
   ...compat.extends('next/core-web-vitals', 'prettier'),
   {
     plugins: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
+import { data } from '@/components/sample/data'
+import { Sample } from '@/components/sample/sample'
+
 export default function Home() {
-  return (
-    <div className="text-xl font-bold flex items-center justify-center pt-10"></div>
-  )
+  return <Sample title={data} />
 }

--- a/src/components/global/badge.tsx
+++ b/src/components/global/badge.tsx
@@ -1,0 +1,16 @@
+import { Badge } from '../ui/badge'
+
+interface Props {
+  text: string
+}
+
+export default function AppBadge({ text }: Props) {
+  return (
+    <Badge
+      variant="outline"
+      className="bg-indigo-500 flex text-white font-bold text-[14px] border-none py-1"
+    >
+      {text}
+    </Badge>
+  )
+}

--- a/src/components/sample/data.ts
+++ b/src/components/sample/data.ts
@@ -1,0 +1,12 @@
+import { SampleTypes } from './type'
+
+export const data: SampleTypes[] = [
+  {
+    id: '1',
+    description: 'This is some sample data for the Sample component.',
+  },
+  {
+    id: '2',
+    description: 'This is another piece of sample data.',
+  },
+]

--- a/src/components/sample/sample.tsx
+++ b/src/components/sample/sample.tsx
@@ -1,7 +1,15 @@
+import { SampleTypes } from './type'
+
 interface Props {
-  title: string
+  title: SampleTypes[]
 }
 
 export function Sample({ title }: Props) {
-  return <div>{title}</div>
+  return (
+    <div>
+      {title.map((item) => (
+        <div key={item.id}>{item.description}</div>
+      ))}
+    </div>
+  )
 }

--- a/src/components/sample/type.ts
+++ b/src/components/sample/type.ts
@@ -1,0 +1,4 @@
+export type SampleTypes = {
+  id: string
+  description: string
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/lib/utils'
+
+const badgeVariants = cva(
+  'inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
+  {
+    variants: {
+      variant: {
+        default:
+          'border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
+        secondary:
+          'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
+        destructive:
+          'border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+        outline:
+          'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+)
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<'span'> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : 'span'
+
+  return (
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a reusable Badge component with multiple visual variants and accessibility-friendly defaults.
  - Added a global app badge for prominent labels.
  - Home page now renders a Sample component that displays a list of sample items instead of an empty placeholder.

- Chores
  - Updated linting configuration to ignore Next.js build output, streamlining development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->